### PR TITLE
disable zoom-out for cnc-ddraw

### DIFF
--- a/wkReSolution/hooks.cpp
+++ b/wkReSolution/hooks.cpp
@@ -65,6 +65,22 @@ BOOL HandleBufferResize(DWORD nWidth, DWORD nHeight, bool bRedraw)
 
 	if (DDObj() && nWidth <= 32767 && nHeight <= 32767 && nWidth && nHeight)
 	{
+		if (GetProcAddress(GetModuleHandleA("ddraw.dll"), "GameHandlesClose")) // detect cnc-ddraw
+		{
+			// Don't allow to zoom out, it isn't supported by cnc-ddraw (yet)
+			DWORD w, h;
+			GetWndSize(WormsWnd(), w, h);
+
+			if (nWidth > w || nHeight > h)
+			{
+				DTWidth = w;
+				DTHeight = h;
+				DDif = DTHeight / DTWidth;
+
+				return result;
+			}
+		}
+
 		TWidth = nWidth;
 		THeight = nHeight;
 		ModifiedSurfaces = 0;


### PR DESCRIPTION
Currently cnc-ddraw does only support to zoom in, but not to zoom out. This pull request detects cnc-ddraw and disables the zoom out feature.

I may add support for zoom out later on as well